### PR TITLE
Remove PayPal payment option from membership page

### DIFF
--- a/content/600-membership.md
+++ b/content/600-membership.md
@@ -18,9 +18,7 @@ Please feel free to print out a [membership application from our site (pdf)](/fi
 
 **Annual Dues: $20.00**
 
-Dues can be paid in person, by mail, or even by via [PayPal](https://www.paypal.com/paypalme/BCARSK3NQT). If you use PayPal, please pay $22 in order to cover PayPal Fees.
-
-To pay by mail, send a check for $20 to:
+Dues can be paid in person or by mail. To pay by mail, send a check for $20 to:
 
 ```text
 BCARS  


### PR DESCRIPTION
Removes the PayPal link and fee surcharge note from the membership page. Dues can still be paid in person or by mail.